### PR TITLE
Check for empty sid's

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -43,7 +43,7 @@ func (p *PolicyBuilder) WithId(id string, lines ...int) *PolicyBuilder {
 func (p *PolicyBuilder) WithStatement(s Statement, lines ...int) *PolicyBuilder {
 
 	for i, existing := range p.doc.inner.Statement.inner {
-		if existing.inner.Sid == s.inner.Sid {
+		if existing.inner.Sid == s.inner.Sid && existing.inner.Sid.inner != "" {
 			p.doc.inner.Statement.inner[i] = s
 			if len(lines) > 0 {
 				p.doc.inner.Statement.r.StartLine = lines[0]


### PR DESCRIPTION
There's an issue when policies with multiple statements that don't include SIDs don't get parsed. Terraform / AWS allows this so this check needs to be included in order to correctly parse all statements